### PR TITLE
Remove undefined method __disableTmpl from payload

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/billink.js
+++ b/view/frontend/web/js/view/payment/method-renderer/billink.js
@@ -153,6 +153,7 @@ define(
                     paymentData = data ? data : quote.paymentMethod();
 
                 delete(paymentData['title']);
+                delete(paymentData['__disableTmpl']);
 
                 fullScreenLoader.startLoader();
 


### PR DESCRIPTION
Magento 2.4.2-p2 (tested Vanilla installation) tries to send this JS method with the payload breaking the sanitizer in the backend

Because it tries to find a reflection method with that name as as setter.

Screenshot refering in frontend error
![image](https://user-images.githubusercontent.com/1163348/132719650-6903ccc2-19f2-4613-b803-64082f80f0fb.png)
![image](https://user-images.githubusercontent.com/1163348/132719751-5baeedd0-4e03-4b73-b7c9-f1e191af9ccd.png)
![image](https://user-images.githubusercontent.com/1163348/132719778-4379d6e9-6644-4a70-b8f9-1e75b0c6cc0b.png)



