### PR TITLE
BILLINK-53 - Fix DOB formatting by providing a second

### DIFF
--- a/Gateway/Request/CustomerDataBuilder.php
+++ b/Gateway/Request/CustomerDataBuilder.php
@@ -102,7 +102,7 @@ class CustomerDataBuilder implements BuilderInterface
 
             $result = array_merge($result, [
                 self::SEX => $this->subjectReader->readPaymentAIField(DataAssignObserver::SEX, $buildSubject),
-                self::BIRTHDATE => $this->dateTime->date('d-m-Y', $birthDate)
+                self::BIRTHDATE => $this->dateTime->date('d-m-Y', $birthDate .' 00:00:01')
             ]);
         }
 


### PR DESCRIPTION
Fixed 01-01-1970 birth from returning "0" which is then considered as "empty" instead of "start of the epoch"